### PR TITLE
Fixed init of AttributeObjectMapping

### DIFF
--- a/src/main/java/cz/muni/ics/perunproxyapi/persistence/AttributeMappingService.java
+++ b/src/main/java/cz/muni/ics/perunproxyapi/persistence/AttributeMappingService.java
@@ -110,7 +110,7 @@ public class AttributeMappingService {
                     if (aom.getLdapName() != null && aom.getLdapName().trim().isEmpty()) {
                         aom.setLdapName(null);
                     }
-                    attributeMap.put(aom.getRpcName(), aom);
+                    attributeMap.put(aom.getIdentifier(), aom);
                 }
                 log.trace("Attributes were initialized: {}", attributeMap.toString());
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- instead of identifier, the RPC name was used when inserting the
entries into the service map
- wrong key caused inability to find the mapping by identifier if the
RPCname was different from identifier

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code or performance improvement
- [ ] Documentation changes or improvements

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My code has tests
- [X] My code has been tested manually
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
