### PR TITLE
Fixed logging of wrong object for credentials

### DIFF
--- a/src/main/java/cz/muni/ics/perunproxyapi/presentation/rest/config/WebSecurityConfiguration.java
+++ b/src/main/java/cz/muni/ics/perunproxyapi/presentation/rest/config/WebSecurityConfiguration.java
@@ -65,7 +65,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
         }
 
         for (BasicAuthCredentials user: credentials) {
-            log.debug("Configuring credentials {} for Basic Auth with role {}.", credentials, ROLE_API_USER);
+            log.debug("Configuring credentials {} for Basic Auth with role {}.", user, ROLE_API_USER);
             auth.inMemoryAuthentication()
                     .withUser(user.getUsername())
                     .password(passwordEncoder().encode(user.getPassword()))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- when initializing User credentials, we have been logging the wrong object, which caused multiple lines with the same content to appear

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code or performance improvement
- [ ] Documentation changes or improvements

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My code has tests
- [X] My code has been tested manually
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
