### PR TITLE
Fixed fetching RPC name from mapping in LDAP adapter

### DIFF
--- a/src/main/java/cz/muni/ics/perunproxyapi/persistence/adapters/impl/ldap/LdapAdapterImpl.java
+++ b/src/main/java/cz/muni/ics/perunproxyapi/persistence/adapters/impl/ldap/LdapAdapterImpl.java
@@ -341,7 +341,7 @@ public class LdapAdapterImpl implements DataAdapter {
                                              @NonNull List<String> attrIdentifiers)
     {
         AttributeObjectMapping loginMapping = this.getMappingForAttrName(loginAttributeIdentifier);
-        if (loginMapping == null || !StringUtils.hasText(loginMapping.getRpcName())) {
+        if (loginMapping == null || !StringUtils.hasText(loginMapping.getLdapName())) {
             log.error("Cannot look for users, name of the LDAP attribute is unknown for identifier {} (mapping:{})",
                     loginAttributeIdentifier, loginMapping);
             throw new IllegalArgumentException("Cannot fetch unknown attribute");


### PR DESCRIPTION
## Description
- we have been searching for an attribute based on the RPC name instead
of LDAP name in one of the methods of LDAPadapter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code or performance improvement
- [ ] Documentation changes or improvements

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My code has tests
- [X] My code has been tested manually
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
